### PR TITLE
support amazon linux

### DIFF
--- a/itamae-plugin-recipe-mackerel-agent.gemspec
+++ b/itamae-plugin-recipe-mackerel-agent.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "toml", "~> 0.1.2"
+
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/lib/itamae/plugin/recipe/mackerel-agent/default.rb
+++ b/lib/itamae/plugin/recipe/mackerel-agent/default.rb
@@ -1,3 +1,11 @@
+require "toml"
+
+# set default attributes
+node['mackerel-agent'] = {} unless node['mackerel-agent']
+node['mackerel-agent']['conf'] = node['mackerel-agent'].fetch('conf', {})
+node['mackerel-agent']['start_on_setup'] = node['mackerel-agent'].fetch('start_on_setup', true)
+node['mackerel-agent']['package-action'] = node['mackerel-agent'].fetch('package-action', :install)
+
 case node[:platform]
 when "debian", "ubuntu"
   remote_file "/etc/apt/sources.list.d/mackerel.list"
@@ -5,18 +13,42 @@ when "debian", "ubuntu"
     command "curl -fsS https://mackerel.io/assets/files/GPG-KEY-mackerel | apt-key add -"
   end
   execute "apt-get update -qq"
-when "redhat", "fedra"
+when "redhat", "fedora"
   execute "import mackerel GPG key" do
     command "rpm --import https://mackerel.io/assets/files/GPG-KEY-mackerel"
   end
   remote_file "/etc/yum.repos.d/mackerel.repo"
+when "amazon"
+  execute "import mackerel GPG key" do
+    command "rpm --import https://mackerel.io/assets/files/GPG-KEY-mackerel"
+  end
+  remote_file "/etc/yum.repos.d/mackerel.repo" do
+    source "./files/etc/yum.repos.d/mackerel-amznlinux.repo"
+  end
 else
   raise "not supported this platform: " + node[:platform]
 end
 
-template "/etc/mackerel-agent/mackerel-agent.conf"
-package "mackerel-agent"
+package "mackerel-agent" do
+  action node['mackerel-agent']['package-action'].to_sym
+  if node['mackerel-agent']['start_on_setup']
+    notifies :restart, "service[mackerel-agent]"
+  end
+end
+
+file "/etc/mackerel-agent/mackerel-agent.conf" do
+  owner "root"
+  group "root"
+  content TOML::Generator.new(node['mackerel-agent']['conf']).body
+  if node['mackerel-agent']['start_on_setup']
+    notifies :restart, "service[mackerel-agent]"
+  end
+end
 
 service "mackerel-agent" do
-  action [:enable, :start]
+  if node['mackerel-agent']['start_on_setup']
+    action [:enable, :start]
+  else
+    action :enable
+  end
 end

--- a/lib/itamae/plugin/recipe/mackerel-agent/files/etc/yum.repos.d/mackerel-amznlinux.repo
+++ b/lib/itamae/plugin/recipe/mackerel-agent/files/etc/yum.repos.d/mackerel-amznlinux.repo
@@ -1,0 +1,5 @@
+[mackerel]
+name=mackerel-agent
+baseurl=http://yum.mackerel.io/amznlinux/$releasever/$basearch
+gpgcheck=1
+enabled=1

--- a/lib/itamae/plugin/recipe/mackerel-agent/templates/etc/mackerel-agent/mackerel-agent.conf.erb
+++ b/lib/itamae/plugin/recipe/mackerel-agent/templates/etc/mackerel-agent/mackerel-agent.conf.erb
@@ -1,1 +1,0 @@
-apikey = "<%= node['mackerel-agent']['apikey'] %>"


### PR DESCRIPTION
I want to install the agent into amazon linux, but I got `not supported this platform: amazon`.
The agent supports amazon linux now https://mackerel.io/ja/blog/entry/2016/03/28/195614 , so I wrote the recipe and fixed some bugs.
- fix typo `fedra`, it seems to be `fedora`
- fix creating the configure files error

> mv: `/tmp/itamae_tmp/1463107899.6121778' から`/etc/mackerel-agent/mackerel-agent.conf' へ移動できません: そのようなファイルやディレクトリはありません
