### PR TITLE
Require node['mackerel-agent']['conf']['apikey'] attribute

### DIFF
--- a/lib/itamae/plugin/recipe/mackerel-agent/default.rb
+++ b/lib/itamae/plugin/recipe/mackerel-agent/default.rb
@@ -59,3 +59,13 @@ service "mackerel-agent" do
     action :enable
   end
 end
+
+node.validate! do
+  {
+    'mackerel-agent': {
+      'conf':{
+        'apikey': string,
+      }
+    }
+  }
+end


### PR DESCRIPTION
apikey is mandatory to start mackerel-agent service.

## if node attribute is not set
```
$ bundle exec itamae ssh --host example.com recipe.rb --dry-run
 INFO : Starting Itamae...
ERROR : 'mackerel-agent->conf->apikey' is required but missing
bundler: failed to load command: itamae
Itamae::Node::ValidationError: Itamae::Node::ValidationError
```