### PR TITLE
Support v2 packages

### DIFF
--- a/lib/itamae/plugin/recipe/mackerel-agent/default.rb
+++ b/lib/itamae/plugin/recipe/mackerel-agent/default.rb
@@ -15,14 +15,14 @@ case node[:platform]
 when "debian", "ubuntu"
   if node[:platform] == "debian" and platform_version_satisfy?('>= 8') or node[:platform] == "ubuntu" and platform_version_satisfy?('>= 16.04')
     execute "import mackerel GPG key v2" do
-      command "curl -fsS https://mackerel.io/file/cert/GPG-KEY-mackerel-v2 | apt-key add -"
+      command "curl -fsSL https://mackerel.io/file/cert/GPG-KEY-mackerel-v2 | apt-key add -"
     end
     remote_file "/etc/apt/sources.list.d/mackerel.list" do
       source "./files/etc/apt/sources.list.d/mackerel-v2.list"
     end
   else
     execute "import mackerel GPG key" do
-      command "curl -fsS https://mackerel.io/file/cert/GPG-KEY-mackerel | apt-key add -"
+      command "curl -fsSL https://mackerel.io/file/cert/GPG-KEY-mackerel | apt-key add -"
     end
     remote_file "/etc/apt/sources.list.d/mackerel.list"
   end

--- a/lib/itamae/plugin/recipe/mackerel-agent/default.rb
+++ b/lib/itamae/plugin/recipe/mackerel-agent/default.rb
@@ -43,7 +43,7 @@ when "redhat", "fedora"
   end
 when "amazon"
   if platform_version_satisfy?('~> 2.0')
-    execute "import mackerel GPG key" do
+    execute "import mackerel GPG key v2" do
       command "rpm --import https://mackerel.io/file/cert/GPG-KEY-mackerel-v2"
     end
     remote_file "/etc/yum.repos.d/mackerel.repo" do

--- a/lib/itamae/plugin/recipe/mackerel-agent/default.rb
+++ b/lib/itamae/plugin/recipe/mackerel-agent/default.rb
@@ -42,7 +42,7 @@ when "redhat", "fedora"
     remote_file "/etc/yum.repos.d/mackerel.repo"
   end
 when "amazon"
-  if platform_version_satisfy?('>~ 2.0')
+  if platform_version_satisfy?('~> 2.0')
     execute "import mackerel GPG key" do
       command "rpm --import https://mackerel.io/file/cert/GPG-KEY-mackerel-v2"
     end

--- a/lib/itamae/plugin/recipe/mackerel-agent/files/etc/apt/sources.list.d/mackerel-v2.list
+++ b/lib/itamae/plugin/recipe/mackerel-agent/files/etc/apt/sources.list.d/mackerel-v2.list
@@ -1,0 +1,1 @@
+deb http://apt.mackerel.io/v2/ mackerel contrib

--- a/lib/itamae/plugin/recipe/mackerel-agent/files/etc/yum.repos.d/mackerel-amznlinux-v2.repo
+++ b/lib/itamae/plugin/recipe/mackerel-agent/files/etc/yum.repos.d/mackerel-amznlinux-v2.repo
@@ -1,0 +1,5 @@
+[mackerel]
+name=mackerel-agent
+baseurl=http://yum.mackerel.io/amznlinux/v2/$releasever/$basearch
+gpgcheck=1
+enabled=1

--- a/lib/itamae/plugin/recipe/mackerel-agent/files/etc/yum.repos.d/mackerel-v2.repo
+++ b/lib/itamae/plugin/recipe/mackerel-agent/files/etc/yum.repos.d/mackerel-v2.repo
@@ -1,0 +1,5 @@
+[mackerel]
+name=mackerel-agent
+baseurl=http://yum.mackerel.io/v2/$basearch
+gpgcheck=1
+enabled=1


### PR DESCRIPTION
update supported distributions.

- RHEL/CentOS 6, 7
- Debian 7, 8, 9
- Ubuntu 14.04, 16.04
- Amazon Linux ~2017/09, 2.0(Release Candidate)