### PR TITLE
fix operator precedence

### DIFF
--- a/lib/itamae/plugin/recipe/mackerel-agent/default.rb
+++ b/lib/itamae/plugin/recipe/mackerel-agent/default.rb
@@ -13,7 +13,7 @@ end
 
 case node[:platform]
 when "debian", "ubuntu"
-  if node[:platform] == "debian" and platform_version_satisfy?('>= 8') or node[:platform] == "ubuntu" and platform_version_satisfy?('>= 16.04')
+  if (node[:platform] == "debian" and platform_version_satisfy?('>= 8')) or (node[:platform] == "ubuntu" and platform_version_satisfy?('>= 16.04'))
     execute "import mackerel GPG key v2" do
       command "curl -fsSL https://mackerel.io/file/cert/GPG-KEY-mackerel-v2 | apt-key add -"
     end


### PR DESCRIPTION
`and` and `or` have same precedence in Ruby.  So it's always false on Debian, I guess.

```ruby
a = (1 and 2 or 3 and false)
p a  #=> false
b = ((1 and 2) or (3 and false))
p b  #=> 2
```