### PR TITLE
Support third party plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ node['mackerel-agent']['conf']['roles'] = ["My-Service:app", "Another-Service:db
 node['mackerel-agent']['plugins'] = ['mackerel-agent-plugins', 'mackerel-check-plugins', 'mkr']
 
 # Install third party plugins (optional)
-node['mackerel-agent']['third_party_plugins'] = [
+node['mackerel-agent']['extra_plugins'] = [
   {
     'name' => 'mackerelio/mackerel-plugin-aws-ecs',
     'version' => 'v0.0.4'

--- a/README.md
+++ b/README.md
@@ -38,7 +38,15 @@ node['mackerel-agent']['conf']['apikey'] = 'YOUR API KEY'
 node['mackerel-agent']['conf']['roles'] = ["My-Service:app", "Another-Service:db"]
 
 # Install official plugins (optional)
-node['mackerel-agent']['plugins'] = ['mackerel-agent-plugins', 'mackerel-check-plugins']
+node['mackerel-agent']['plugins'] = ['mackerel-agent-plugins', 'mackerel-check-plugins', 'mkr']
+
+# Install third party plugins (optional)
+node['mackerel-agent']['third_party_plugins'] = [
+  {
+    'name' => 'mackerelio/mackerel-plugin-aws-ecs',
+    'version' => 'v0.0.4'
+  }
+]
 
 # Enable plugins (optional)
 node['mackerel-agent']['conf']['plugin.metrics.vmstat'] = {

--- a/lib/itamae/plugin/recipe/mackerel-agent/default.rb
+++ b/lib/itamae/plugin/recipe/mackerel-agent/default.rb
@@ -6,7 +6,7 @@ node['mackerel-agent']['conf'] = node['mackerel-agent'].fetch('conf', {})
 node['mackerel-agent']['start_on_setup'] = node['mackerel-agent'].fetch('start_on_setup', true)
 node['mackerel-agent']['package-action'] = node['mackerel-agent'].fetch('package-action', :install)
 node['mackerel-agent']['plugins'] = node['mackerel-agent'].fetch('plugins', [])
-node['mackerel-agent']['third_party_plugins'] = node['mackerel-agent'].fetch('third_party_plugins', [])
+node['mackerel-agent']['extra_plugins'] = node['mackerel-agent'].fetch('extra_plugins', [])
 
 def platform_version_satisfy?(op)
   Gem::Requirement.create(op).satisfied_by?(Gem::Version.create(node[:platform_version]))
@@ -75,9 +75,9 @@ node['mackerel-agent']['plugins'].each do |plugin|
   end
 end
 
-node['mackerel-agent']['third_party_plugins'].each do |third_party_plugin|
-  execute "mkr plugin install #{third_party_plugin['name']}" do
-    command "mkr plugin install --upgrade #{third_party_plugin['name']}@#{third_party_plugin['version']}"
+node['mackerel-agent']['extra_plugins'].each do |extra_plugin|
+  execute "mkr plugin install #{extra_plugin['name']}" do
+    command "mkr plugin install --upgrade #{extra_plugin['name']}@#{extra_plugin['version']}"
   end
 end
 

--- a/lib/itamae/plugin/recipe/mackerel-agent/default.rb
+++ b/lib/itamae/plugin/recipe/mackerel-agent/default.rb
@@ -6,6 +6,7 @@ node['mackerel-agent']['conf'] = node['mackerel-agent'].fetch('conf', {})
 node['mackerel-agent']['start_on_setup'] = node['mackerel-agent'].fetch('start_on_setup', true)
 node['mackerel-agent']['package-action'] = node['mackerel-agent'].fetch('package-action', :install)
 node['mackerel-agent']['plugins'] = node['mackerel-agent'].fetch('plugins', [])
+node['mackerel-agent']['third_party_plugins'] = node['mackerel-agent'].fetch('third_party_plugins', [])
 
 def platform_version_satisfy?(op)
   Gem::Requirement.create(op).satisfied_by?(Gem::Version.create(node[:platform_version]))
@@ -71,6 +72,12 @@ end
 node['mackerel-agent']['plugins'].each do |plugin|
   package plugin do
     action :install
+  end
+end
+
+node['mackerel-agent']['third_party_plugins'].each do |third_party_plugin|
+  execute "mkr plugin install #{third_party_plugin['name']}" do
+    command "mkr plugin install --upgrade #{third_party_plugin['name']}@#{third_party_plugin['version']}"
   end
 end
 


### PR DESCRIPTION
This PR is support `mkr plugin install`.

```
node['mackerel-agent']['extra_plugins'] = [
  {
    'name' => 'mackerelio/mackerel-plugin-aws-ecs',
    'version' => 'v0.0.4'
  }
]
```